### PR TITLE
Stats from log files

### DIFF
--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -2,18 +2,10 @@ import { NextResponse } from 'next/server';
 
 import { updateSingleUser } from '../../../lib/api';
 import prisma from '../../../lib/db';
-import { validateBitcoinAddress } from '../../../utils/validateBitcoinAddress';
 
 export async function POST(request: Request) {
   try {
     const { address } = await request.json();
-
-    if (!validateBitcoinAddress(address)) {
-      return NextResponse.json(
-        { error: 'Invalid Bitcoin address' },
-        { status: 400 }
-      );
-    }
 
     // Check if user with the given address already exists
     const existingUser = await prisma.user.findUnique({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,9 +9,9 @@ import Providers from '../components/Providers';
 const lato = Lato({ subsets: ['latin'], weight: ['400', '700'] });
 
 export const metadata: Metadata = {
-  title: 'CKstats',
+  title: 'CKstats (hydrapool)',
   description:
-    'Real-time and historical statistics for the CKPool Bitcoin mining pool using data from their API.',
+    'CKPool stats for Hydrapool. View your stats and hashrate.',
 };
 
 export default function RootLayout({

--- a/app/top-difficulties/page.tsx
+++ b/app/top-difficulties/page.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 import TopUserDifficulties from '../../components/TopUserDifficulties';
 
 export const metadata = {
-  title: 'Top 100 User Difficulties - CKstats',
-  description: 'View the top 100 user difficulties on CKPool.',
+  title: 'Top 100 User Difficulties',
+  description: 'View the top 100 user difficulties on Hydrapool.',
 };
 
 export default function TopDifficultiesPage() {

--- a/app/top-hashrates/page.tsx
+++ b/app/top-hashrates/page.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 import TopUserHashrates from '../../components/TopUserHashrates';
 
 export const metadata = {
-  title: 'Top 100 User Hashrates - CKstats',
-  description: 'View the top 100 user hashrates on CKPool.',
+  title: 'Top 100 User Hashrates',
+  description: 'View the top 100 user hashrates on Hydrapool.',
 };
 
 export default function TopHashratesPage() {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -22,7 +22,7 @@ const Footer: React.FC = () => {
             </svg>
           </a>
           <a
-            href="https://github.com/mrv777/ckstats"
+            href="https://github.com/poo2win/ckstats"
             target="_blank"
             rel="noopener noreferrer"
             className="hover:text-primary"
@@ -40,7 +40,7 @@ const Footer: React.FC = () => {
         </div>
       </div>
       <div>
-        <p>Always free, always open source.</p>
+        <p>Built on CKStats. Donation address for original author.</p>
         <p className="break-all">
           Donations: bc1qz9vvexjmexe8pr2aueuz6x0v94ulkx2m2sp6lr
         </p>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -60,13 +60,6 @@ export default function Header() {
 
   const handleAddAddress = async () => {
     const trimmedAddress = address.trim();
-    if (!validateBitcoinAddress(trimmedAddress)) {
-      setModalMessage('Invalid Bitcoin address');
-      setIsError(true);
-      modalRef.current?.showModal();
-      return;
-    }
-
     addUserMutation.mutate(trimmedAddress);
   };
 
@@ -81,7 +74,7 @@ export default function Header() {
         <div className="form-control flex-grow md:flex-grow-0">
           <input
             type="text"
-            placeholder="Enter Bitcoin address"
+            placeholder="Enter username"
             className="input input-bordered w-full md:w-96 text-sm"
             value={address}
             onChange={(e) => setAddress(e.target.value.trim())}
@@ -116,9 +109,8 @@ export default function Header() {
       <dialog ref={modalRef} className="modal modal-bottom sm:modal-middle">
         <form method="dialog" className="modal-box">
           <h3
-            className={`font-bold text-lg ${
-              isError ? 'text-error' : 'text-success'
-            }`}
+            className={`font-bold text-lg ${isError ? 'text-error' : 'text-success'
+              }`}
           >
             {isError ? 'Error' : 'Success'}
           </h3>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -67,7 +67,7 @@ export default function Header() {
     <header className="navbar bg-base-100">
       <div className="flex-1 hidden md:inline-flex">
         <Link href="/" className="btn btn-ghost normal-case text-xl">
-          CKPool Stats
+          CKPool Stats (Hydra Pool)
         </Link>
       </div>
       <div className="flex-none gap-1 sm:gap-2 flex-grow md:flex-grow-0">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -67,7 +67,7 @@ export default function Header() {
     <header className="navbar bg-base-100">
       <div className="flex-1 hidden md:inline-flex">
         <Link href="/" className="btn btn-ghost normal-case text-xl">
-          CKPool Stats (Hydra Pool)
+          Hydrapool Stats
         </Link>
       </div>
       <div className="flex-none gap-1 sm:gap-2 flex-grow md:flex-grow-0">

--- a/components/PoolStatsDisplay.tsx
+++ b/components/PoolStatsDisplay.tsx
@@ -127,15 +127,15 @@ export default function PoolStatsDisplay({
                 <div className="stat-value text-2xl">
                   {stats.hashrate6hr && stats.diff
                     ? formatDuration(
-                        calculateAverageTimeToBlock(
-                          stats.hashrate6hr,
-                          (stats.accepted * BigInt(10000)) /
-                            BigInt(Math.round(Number(stats.diff) * 100))
-                        )
+                      calculateAverageTimeToBlock(
+                        stats.hashrate6hr,
+                        (stats.accepted * BigInt(10000)) /
+                        BigInt(Math.round(Number(stats.diff) * 100))
                       )
+                    )
                     : 'N/A'}
                 </div>
-                <div className="stat-desc">
+                {/* <div className="stat-desc">
                   <Link
                     href="https://mempool.space/mining/pool/solock"
                     target="_blank"
@@ -143,7 +143,7 @@ export default function PoolStatsDisplay({
                   >
                     Found Blocks
                   </Link>
-                </div>
+                </div> */}
               </div>
             </div>
           </div>

--- a/components/TopUserDifficulties.tsx
+++ b/components/TopUserDifficulties.tsx
@@ -81,7 +81,9 @@ export default async function TopUserDifficulties({
                       )}
                     </td>
                     <td>
-                      {user.address}
+                      <Link href={`/users/${user.address}`} className="hover:underline">
+                        {user.address}
+                      </Link>
                     </td>
 
                     {limit > SMALL_LIMIT ? (

--- a/components/TopUserDifficulties.tsx
+++ b/components/TopUserDifficulties.tsx
@@ -36,7 +36,7 @@ export default async function TopUserDifficulties({
               <thead>
                 <tr>
                   <th>Rank</th>
-                  <th>Address</th>
+                  <th>User</th>
 
                   {limit > SMALL_LIMIT ? (
                     <>
@@ -81,7 +81,7 @@ export default async function TopUserDifficulties({
                       )}
                     </td>
                     <td>
-                      {user.address.slice(0, 6)}...{user.address.slice(-4)}
+                      {user.address}
                     </td>
 
                     {limit > SMALL_LIMIT ? (

--- a/components/TopUserHashrates.tsx
+++ b/components/TopUserHashrates.tsx
@@ -36,7 +36,7 @@ export default async function TopUserHashrates({
               <thead>
                 <tr>
                   <th>Rank</th>
-                  <th>Address</th>
+                  <th>User</th>
                   {limit > SMALL_LIMIT ? (
                     <>
                       <th>Active Workers</th>
@@ -56,7 +56,7 @@ export default async function TopUserHashrates({
                   <tr key={user.address}>
                     <td>{index + 1}</td>
                     <td>
-                      {user.address.slice(0, 6)}...{user.address.slice(-4)}
+                      {user.address}
                     </td>
 
                     {limit > SMALL_LIMIT ? (

--- a/components/TopUserHashrates.tsx
+++ b/components/TopUserHashrates.tsx
@@ -56,7 +56,9 @@ export default async function TopUserHashrates({
                   <tr key={user.address}>
                     <td>{index + 1}</td>
                     <td>
-                      {user.address}
+                      <Link href={`/users/${user.address}`} className="hover:underline">
+                        {user.address}
+                      </Link>
                     </td>
 
                     {limit > SMALL_LIMIT ? (

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -258,7 +258,7 @@ export async function updateSingleUser(address: string): Promise<void> {
 
       // Update or create workers
       for (const workerData of userData.worker) {
-        const workerName = workerData.workername.split('.')[1];
+        const workerName = workerData.workername; // show full worker name
         await prisma.worker.upsert({
           where: {
             userAddress_name: {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "seed": "node scripts/seed.js",
     "update-stats": "ts-node scripts/updateStats.ts",
     "update-users": "node scripts/updateUsers.js",
+    "update-users-from-logs": "node scripts/updateUsersFromLogs.js",
     "cleanup": "node scripts/cleanOldStats.js",
     "vacuum": "prisma db execute --stdin < scripts/vacuum.sql",
     "test": "jest",

--- a/scripts/updateUsersFromLogs.js
+++ b/scripts/updateUsersFromLogs.js
@@ -1,0 +1,189 @@
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+const fs = require('fs');
+const path = require('path');
+
+const convertHashrate = (value) => {
+  const units = { P: 1e15, T: 1e12, G: 1e9, M: 1e6, K: 1e3 };
+  // Updated regex to handle scientific notation
+  const match = value.match(/^(\d+(\.\d+)?(?:e[+-]\d+)?)([PTGMK])$/i);
+  if (match) {
+    const [, num, , unit] = match;
+    // Parse the number, which now handles scientific notation
+    const parsedNum = parseFloat(num);
+    return BigInt(Math.round(parsedNum * units[unit.toUpperCase()]));
+  }
+  return value;
+};
+
+async function readUserData(filename) {
+  const filePath = path.join(process.env.LOGS_DIR, `users/${filename}`);
+  if (!fs.existsSync(filePath)) {
+    console.log(`User data file not found: ${filePath}`);
+    return null;
+  } else {
+    console.log(`Reading user data from file: ${filePath}`);
+    const data = await fs.promises.readFile(filePath, 'utf8');
+    return JSON.parse(data);
+  }
+}
+
+async function updateUser(address, userData) {
+  await prisma.user.upsert({
+    where: { address },
+    update: {
+      authorised: BigInt(userData.authorised),
+    },
+    create: {
+      address,
+      authorised: BigInt(userData.authorised),
+    },
+  });
+
+  // Create a new UserStats entry
+  await prisma.userStats.create({
+    data: {
+      user: { connect: { address } },
+      hashrate1m: convertHashrate(userData.hashrate1m),
+      hashrate5m: convertHashrate(userData.hashrate5m),
+      hashrate1hr: convertHashrate(userData.hashrate1hr),
+      hashrate1d: convertHashrate(userData.hashrate1d),
+      hashrate7d: convertHashrate(userData.hashrate7d),
+      lastShare: BigInt(userData.lastshare),
+      workerCount: userData.workers,
+      shares: BigInt(userData.shares),
+      bestShare: parseFloat(userData.bestshare),
+      bestEver: BigInt(userData.bestever),
+    },
+  });
+}
+
+async function updateWorker(address, workerData) {
+  if (!workerData.workername) {
+    console.log(`Worker data for address ${address} is missing a valid name. Skipping.`);
+    return;
+  }
+
+  const workerName = workerData.workername.includes('.')
+    ? workerData.workername.split('.')[1]
+    : workerData.workername.includes('_')
+      ? workerData.workername.split('_')[1]
+      : '';
+
+  const worker = await prisma.worker.upsert({
+    where: {
+      userAddress_name: {
+        userAddress: address,
+        name: workerName,
+      },
+    },
+    update: {
+      hashrate1m: convertHashrate(workerData.hashrate1m),
+      hashrate5m: convertHashrate(workerData.hashrate5m),
+      hashrate1hr: convertHashrate(workerData.hashrate1hr),
+      hashrate1d: convertHashrate(workerData.hashrate1d),
+      hashrate7d: convertHashrate(workerData.hashrate7d),
+      lastUpdate: new Date(workerData.lastshare * 1000),
+      shares: BigInt(workerData.shares),
+      bestShare: parseFloat(workerData.bestshare),
+      bestEver: BigInt(workerData.bestever),
+    },
+    create: {
+      userAddress: address,
+      name: workerName,
+      hashrate1m: convertHashrate(workerData.hashrate1m),
+      hashrate5m: convertHashrate(workerData.hashrate5m),
+      hashrate1hr: convertHashrate(workerData.hashrate1hr),
+      hashrate1d: convertHashrate(workerData.hashrate1d),
+      hashrate7d: convertHashrate(workerData.hashrate7d),
+      lastUpdate: new Date(workerData.lastshare * 1000),
+      shares: BigInt(workerData.shares),
+      bestShare: parseFloat(workerData.bestshare),
+      bestEver: BigInt(workerData.bestever),
+    },
+  });
+
+  // Create a new WorkerStats entry
+  await prisma.workerStats.create({
+    data: {
+      workerId: worker.id,
+      hashrate1m: convertHashrate(workerData.hashrate1m),
+      hashrate5m: convertHashrate(workerData.hashrate5m),
+      hashrate1hr: convertHashrate(workerData.hashrate1hr),
+      hashrate1d: convertHashrate(workerData.hashrate1d),
+      hashrate7d: convertHashrate(workerData.hashrate7d),
+      shares: BigInt(workerData.shares),
+      bestShare: parseFloat(workerData.bestshare),
+      bestEver: BigInt(workerData.bestever),
+    },
+  });
+}
+
+async function updateUserAndWorkers(username) {
+  try {
+    const userData = await readUserData(username);
+    if (!userData) {
+      console.log(`No user data found for username: ${username}`);
+      return;
+    }
+    await prisma.$transaction(async () => {
+      await updateUser(username, userData,);
+      await Promise.all(userData.worker.map(w => updateWorker(username, w)));
+    });
+    console.log(`Updated user and workers for: ${username}`);
+  } catch (error) {
+    console.error(`Error updating user ${username}:`, error);
+  }
+}
+
+async function updateUsersFromLogs() {
+  try {
+    let usersDir = path.join(process.env.LOGS_DIR, 'users');
+    const files = fs.readdirSync(usersDir);
+    console.log(`Found ${files.length} files in ${usersDir}`);
+    if (files.length === 0) {
+      console.log('No files found in the users directory.');
+      return;
+    }
+
+    // Get directories only and save them as userNames
+    const users = [];
+    for (const file of files) {
+      users.push(file);
+    }
+
+    console.log(`Found ${users.length} user directories`);
+
+    // Define batch size for processing
+    const batchSize = 5;
+
+    // Process users in batches
+    for (let i = 0; i < users.length; i += batchSize) {
+      const batch = users.slice(i, i + batchSize);
+      await Promise.all(batch.map(user => updateUserAndWorkers(user)));
+    }
+
+    console.log('All users and workers updated successfully');
+  } catch (error) {
+    console.error('Error updating users:', error);
+  } finally {
+    await prisma.$disconnect();
+    // Force garbage collection if running in Node.js with the --expose-gc flag
+    if (global.gc) {
+      global.gc();
+    }
+  }
+}
+
+(async () => {
+  try {
+    await updateUsersFromLogs();
+  } catch (error) {
+    console.error('Unhandled error:', error);
+  } finally {
+    // Ensure that Prisma client is disconnected
+    await prisma.$disconnect();
+    // Ensure that the process exits even if there are any hanging promises
+    process.exit(0);
+  }
+})();

--- a/scripts/updateUsersFromLogs.js
+++ b/scripts/updateUsersFromLogs.js
@@ -64,11 +64,7 @@ async function updateWorker(address, workerData) {
     return;
   }
 
-  const workerName = workerData.workername.includes('.')
-    ? workerData.workername.split('.')[1]
-    : workerData.workername.includes('_')
-      ? workerData.workername.split('_')[1]
-      : '';
+  const workerName = workerData.workername; // Show full worker name
 
   const worker = await prisma.worker.upsert({
     where: {


### PR DESCRIPTION
Support running ckstats for local ckpool stats

We can then use this on p2poolv2 instances to provide the user/miner/admin access to stats about their devices.

We don't pull data from ckpool.com/pool|users URL, instead get the data directly from the local filesystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a script to update user and worker data from log files, including a utility to convert hashrate units.
  - Introduced a new npm script to run the user update process from logs.

- **Improvements**
  - Enhanced data seeding to support fetching pool statistics from either an API or local files.
  - Updated worker name handling to use the full worker name for better accuracy.
  - Updated metadata and descriptions throughout the app to reference "Hydrapool" instead of "CKPool."
  - Improved user and worker tables to display full usernames as clickable links.

- **UI Updates**
  - Changed input placeholders and labels from "Address" to "User" and updated header/footer text to reflect Hydrapool branding.
  - Updated footer with a new GitHub link and revised open source messaging.

- **Bug Fixes**
  - Removed client-side and server-side Bitcoin address validation, allowing any username format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->