### PR TITLE
Hashrate graph now dynamically scales units, standardised ISO handling

### DIFF
--- a/components/PoolStatsChart.tsx
+++ b/components/PoolStatsChart.tsx
@@ -245,7 +245,9 @@ export default function PoolStatsChart({ data }: PoolStatsChartProps) {
 
   const renderHashrateChart = () => (
     <div className="h-80 w-full mb-8">
-      <h2 className="text-xl font-bold mb-2">Hashrate (PH/s)</h2>
+      <h2 className="text-xl font-bold mb-2">
+        Hashrate ({hashrateUnit.iso}H/s)
+      </h2>
       <ResponsiveContainer width="100%" height="100%">
         <LineChart
           data={formattedData}

--- a/components/PoolStatsChart.tsx
+++ b/components/PoolStatsChart.tsx
@@ -178,7 +178,7 @@ export default function PoolStatsChart({ data }: PoolStatsChartProps) {
   ];
 
   const spsTooltipFormatter = (value: number, name: string) => [
-    `${value.toFixed(0)} SPS`,
+    `${value > 10 ? value.toFixed(0) : value.toFixed(1)} SPS`,
     name,
   ];
 

--- a/components/PoolStatsChart.tsx
+++ b/components/PoolStatsChart.tsx
@@ -128,6 +128,28 @@ export default function PoolStatsChart({ data }: PoolStatsChartProps) {
     },
   ];
 
+  // Calculate the maximum hashrate
+  let maxHashrate;
+  {
+    const fields: (keyof PoolStats)[] = [
+      'hashrate5m',
+      'hashrate15m',
+      'hashrate1hr',
+      'hashrate6hr',
+      'hashrate1d',
+      'hashrate7d',
+    ];
+
+    maxHashrate = data
+      .flatMap((entry) => fields.map((field) => entry[field]))
+      .reduce((max, current) => (max > current ? max : current), BigInt(0));
+
+    //maxHashrate = Math.max(
+    //  ...data.flatMap((entry) => fields.map((field) => entry[field]))
+    //);
+  }
+  console.log(maxHashrate);
+
   // Reverse the data array
   const reversedData = [...data].reverse();
 

--- a/components/PoolStatsChart.tsx
+++ b/components/PoolStatsChart.tsx
@@ -15,6 +15,8 @@ import {
 } from 'recharts';
 
 import { PoolStats } from '../lib/entities/PoolStats';
+import { calculateDivisor } from '../utils/helpers';
+
 interface PoolStatsChartProps {
   data: PoolStats[];
 }
@@ -129,26 +131,19 @@ export default function PoolStatsChart({ data }: PoolStatsChartProps) {
   ];
 
   // Calculate the maximum hashrate
-  let maxHashrate;
-  {
-    const fields: (keyof PoolStats)[] = [
-      'hashrate5m',
-      'hashrate15m',
-      'hashrate1hr',
-      'hashrate6hr',
-      'hashrate1d',
-      'hashrate7d',
-    ];
+  const hashrateFields: (keyof PoolStats)[] = [
+    'hashrate5m',
+    'hashrate15m',
+    'hashrate1hr',
+    'hashrate6hr',
+    'hashrate1d',
+    'hashrate7d',
+  ];
+  const maxHashrate = data
+    .flatMap((entry) => hashrateFields.map((field) => entry[field]))
+    .reduce((max, current) => (max > current ? max : current), BigInt(0));
 
-    maxHashrate = data
-      .flatMap((entry) => fields.map((field) => entry[field]))
-      .reduce((max, current) => (max > current ? max : current), BigInt(0));
-
-    //maxHashrate = Math.max(
-    //  ...data.flatMap((entry) => fields.map((field) => entry[field]))
-    //);
-  }
-  console.log(maxHashrate);
+  const hashrateDivisor: number = calculateDivisor(Number(maxHashrate));
 
   // Reverse the data array
   const reversedData = [...data].reverse();
@@ -162,13 +157,13 @@ export default function PoolStatsChart({ data }: PoolStatsChartProps) {
       hour: '2-digit',
       minute: '2-digit',
     }),
-    hashrate1m: Number(item.hashrate1m) / 1000000000000000,
-    hashrate5m: Number(item.hashrate5m) / 1000000000000000,
-    hashrate15m: Number(item.hashrate15m) / 1000000000000000,
-    hashrate1hr: Number(item.hashrate1hr) / 1000000000000000,
-    hashrate6hr: Number(item.hashrate6hr) / 1000000000000000,
-    hashrate1d: Number(item.hashrate1d) / 1000000000000000,
-    hashrate7d: Number(item.hashrate7d) / 1000000000000000,
+    hashrate1m: Number(item.hashrate1m) / hashrateDivisor,
+    hashrate5m: Number(item.hashrate5m) / hashrateDivisor,
+    hashrate15m: Number(item.hashrate15m) / hashrateDivisor,
+    hashrate1hr: Number(item.hashrate1hr) / hashrateDivisor,
+    hashrate6hr: Number(item.hashrate6hr) / hashrateDivisor,
+    hashrate1d: Number(item.hashrate1d) / hashrateDivisor,
+    hashrate7d: Number(item.hashrate7d) / hashrateDivisor,
     SPS1m: item.SPS1m ?? 0,
     SPS5m: item.SPS5m ?? 0,
     SPS15m: item.SPS15m ?? 0,

--- a/components/PoolStatsChart.tsx
+++ b/components/PoolStatsChart.tsx
@@ -15,7 +15,7 @@ import {
 } from 'recharts';
 
 import { PoolStats } from '../lib/entities/PoolStats';
-import { calculateDivisor } from '../utils/helpers';
+import { ISOUnit, findISOUnit } from '../utils/helpers';
 
 interface PoolStatsChartProps {
   data: PoolStats[];
@@ -143,7 +143,9 @@ export default function PoolStatsChart({ data }: PoolStatsChartProps) {
     .flatMap((entry) => hashrateFields.map((field) => entry[field]))
     .reduce((max, current) => (max > current ? max : current), BigInt(0));
 
-  const hashrateDivisor: number = calculateDivisor(Number(maxHashrate));
+  // Find out the nearest ISO unit
+  const hashrateUnit: ISOUnit = findISOUnit(Number(maxHashrate));
+  const hashrateDivisor: number = hashrateUnit.threshold;
 
   // Reverse the data array
   const reversedData = [...data].reverse();
@@ -171,7 +173,7 @@ export default function PoolStatsChart({ data }: PoolStatsChartProps) {
   }));
 
   const hashrateTooltipFormatter = (value: number, name: string) => [
-    `${value.toLocaleString(undefined, { maximumFractionDigits: 1 })} PH/s`,
+    `${value.toLocaleString(undefined, { maximumFractionDigits: 1 })} ${hashrateUnit.iso}H/s`,
     name,
   ];
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,42 +1,41 @@
+export interface ISOUnit {
+  threshold: number;
+  iso: string;
+}
+
+// An array oif all ISO units we support.
+// Make sure you check for 0 if you use this.
+const isoUnits: ISOUnit[] = [
+  { threshold: 1e21, iso: 'Z' },
+  { threshold: 1e18, iso: 'E' },
+  { threshold: 1e15, iso: 'P' },
+  { threshold: 1e12, iso: 'T' },
+  { threshold: 1e9, iso: 'G' },
+  { threshold: 1e6, iso: 'M' },
+  { threshold: 1e3, iso: 'k' },
+  { threshold: 1e0, iso: '' },
+] as const;
+
+
 export function formatNumber(num: number | bigint | string): string {
   const absNum = Math.abs(Number(num));
-  
-  if (absNum >= 1e21) {
-    return (Number(num) / 1e21).toFixed(2) + ' Z';
-  } else if (absNum >= 1e18) {
-    return (Number(num) / 1e18).toFixed(2) + ' E';
-  } else if (absNum >= 1e15) {
-    return (Number(num) / 1e15).toFixed(2) + ' P';
-  } else if (absNum >= 1e12) {
-    return (Number(num) / 1e12).toFixed(2) + ' T';
-  } else if (absNum >= 1e9) {
-    return (Number(num) / 1e9).toFixed(2) + ' G';
-  } else if (absNum >= 1e6) {
-    return (Number(num) / 1e6).toFixed(2) + ' M';
-  } else if (absNum >= 1e3) {
-    return (Number(num) / 1e3).toFixed(2) + ' k';
-  } else {
-    return num.toLocaleString();
+
+  for (const unit of isoUnits) {
+    if (absNum >= unit.threshold) {
+      return (Number(num) / unit.threshold).toFixed(2) + ' ' + unit.iso;
+    }
   }
+
+  return num.toLocaleString();
 }
 
 export function formatHashrate(num: string | bigint | number): string {
   const numberValue = Number(num);
   const absNum = Math.abs(numberValue);
   
-  const units: { threshold: number; suffix: string }[] = [
-    { threshold: 1e21, suffix: ' ZH/s' },
-    { threshold: 1e18, suffix: ' EH/s' },
-    { threshold: 1e15, suffix: ' PH/s' },
-    { threshold: 1e12, suffix: ' TH/s' },
-    { threshold: 1e9, suffix: ' GH/s' },
-    { threshold: 1e6, suffix: ' MH/s' },
-    { threshold: 1e3, suffix: ' kH/s' }
-  ];
-
-  for (const unit of units) {
+  for (const unit of isoUnits) {
     if (absNum >= unit.threshold) {
-      return (numberValue / unit.threshold).toLocaleString(undefined, { maximumFractionDigits: 2 }) + unit.suffix;
+      return (numberValue / unit.threshold).toLocaleString(undefined, { maximumFractionDigits: 2 }) + ' '+unit.iso+'H/s';
     }
   }
 
@@ -56,26 +55,16 @@ export function convertHashrate(value: string): bigint {
   return BigInt(value);
 };
 
-export function calculateDivisor(num: number): number {
+export function findISOUnit(num: number): ISOUnit {
   const absNum = Math.abs(num);
 
-  const units: { threshold: number; suffix: string }[] = [
-    { threshold: 1e21, suffix: ' ZH/s' },
-    { threshold: 1e18, suffix: ' EH/s' },
-    { threshold: 1e15, suffix: ' PH/s' },
-    { threshold: 1e12, suffix: ' TH/s' },
-    { threshold: 1e9, suffix: ' GH/s' },
-    { threshold: 1e6, suffix: ' MH/s' },
-    { threshold: 1e3, suffix: ' kH/s' }
-  ];
-
-  for (const unit of units) {
+  for (const unit of isoUnits) {
     if (absNum >= unit.threshold) {
-      return(unit.threshold);
+      return(unit);
     }
   }
 
-  return 1;
+  return {threshold: 1, iso: ''};
 }
 
 export function formatTimeAgo(date: Date | number | string, minDiff: number = 1): string {

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -3,7 +3,7 @@ export interface ISOUnit {
   iso: string;
 }
 
-// An array oif all ISO units we support.
+// An array of all ISO units we support.
 // Make sure you check for 0 if you use this.
 const isoUnits: ISOUnit[] = [
   { threshold: 1e21, iso: 'Z' },
@@ -43,14 +43,14 @@ export function formatHashrate(num: string | bigint | number): string {
 }
 
 export function convertHashrate(value: string): bigint {
-  const units = { Z: 1e21, E: 1e18, P: 1e15, T: 1e12, G: 1e9, M: 1e6, K: 1e3 };
   // Updated regex to handle scientific notation
   const match = value.match(/^(\d+(\.\d+)?(?:e[+-]\d+)?)([ZEPTGMK])$/i);
   if (match) {
     const [, num, , unit] = match;
     // Parse the number, which now handles scientific notation
     const parsedNum = parseFloat(num);
-    return BigInt(Math.round(parsedNum * units[unit.toUpperCase()]));
+    const isoUnit = isoUnits.find((u) => u.iso.toUpperCase() === unit.toUpperCase()) || { threshold: 1, iso: '' };
+    return BigInt(Math.round(parsedNum * isoUnit.threshold));
   }
   return BigInt(value);
 };

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -44,9 +44,9 @@ export function formatHashrate(num: string | bigint | number): string {
 }
 
 export function convertHashrate(value: string): bigint {
-  const units = { E: 1e18, P: 1e15, T: 1e12, G: 1e9, M: 1e6, K: 1e3 };
+  const units = { Z: 1e21, E: 1e18, P: 1e15, T: 1e12, G: 1e9, M: 1e6, K: 1e3 };
   // Updated regex to handle scientific notation
-  const match = value.match(/^(\d+(\.\d+)?(?:e[+-]\d+)?)([EPTGMK])$/i);
+  const match = value.match(/^(\d+(\.\d+)?(?:e[+-]\d+)?)([ZEPTGMK])$/i);
   if (match) {
     const [, num, , unit] = match;
     // Parse the number, which now handles scientific notation

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -25,12 +25,13 @@ export function formatHashrate(num: string | bigint | number): string {
   const absNum = Math.abs(numberValue);
   
   const units: { threshold: number; suffix: string }[] = [
+    { threshold: 1e21, suffix: ' ZH/s' },
     { threshold: 1e18, suffix: ' EH/s' },
     { threshold: 1e15, suffix: ' PH/s' },
     { threshold: 1e12, suffix: ' TH/s' },
     { threshold: 1e9, suffix: ' GH/s' },
     { threshold: 1e6, suffix: ' MH/s' },
-    { threshold: 1e3, suffix: ' KH/s' }
+    { threshold: 1e3, suffix: ' kH/s' }
   ];
 
   for (const unit of units) {

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -56,6 +56,28 @@ export function convertHashrate(value: string): bigint {
   return BigInt(value);
 };
 
+export function calculateDivisor(num: number): number {
+  const absNum = Math.abs(num);
+
+  const units: { threshold: number; suffix: string }[] = [
+    { threshold: 1e21, suffix: ' ZH/s' },
+    { threshold: 1e18, suffix: ' EH/s' },
+    { threshold: 1e15, suffix: ' PH/s' },
+    { threshold: 1e12, suffix: ' TH/s' },
+    { threshold: 1e9, suffix: ' GH/s' },
+    { threshold: 1e6, suffix: ' MH/s' },
+    { threshold: 1e3, suffix: ' kH/s' }
+  ];
+
+  for (const unit of units) {
+    if (absNum >= unit.threshold) {
+      return(unit.threshold);
+    }
+  }
+
+  return 1;
+}
+
 export function formatTimeAgo(date: Date | number | string, minDiff: number = 1): string {
   const now = new Date();
   const lastUpdate = new Date(date);


### PR DESCRIPTION
Previously, the hashrate graph only displayed PH/s scale data.  It can now scale from H/s to ZH/s.  This suits home miners much better, as they tend to have hashrates far below PH/s.

I also introduced a new ISOUnit interface and consolidated many of the ISO thresholds and ISO codes into this unified system.  Some of the scripts are still using their separate definitions, but still, it is a lot more consolidated than it was.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hashrate values in charts now automatically scale and display using the most appropriate ISO unit (e.g., k, M, G, T, P, E, Z), making data easier to read across different magnitudes.
  * Added support for the 'Z' (zetta) unit in hashrate formatting and conversion.

* **Improvements**
  * Chart labels and tooltips dynamically update to reflect the selected unit for hashrate values.
  * Enhanced number and hashrate formatting for consistency and clarity throughout the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->