### PR TITLE
Updated the maxHashrate calculation

### DIFF
--- a/components/PoolStatsChart.tsx
+++ b/components/PoolStatsChart.tsx
@@ -144,8 +144,6 @@ export default function PoolStatsChart({ data }: PoolStatsChartProps) {
   // Find out the nearest ISO unit
   const hashrateUnit: ISOUnit = findISOUnit(Number(maxHashrate));
   const hashrateDivisor: number = hashrateUnit.threshold;
-  console.log(maxHashrate);
-  console.log(hashrateUnit);
 
   // Reverse the data array
   const reversedData = [...data].reverse();

--- a/components/PoolStatsChart.tsx
+++ b/components/PoolStatsChart.tsx
@@ -135,7 +135,9 @@ export default function PoolStatsChart({ data }: PoolStatsChartProps) {
     ...data.flatMap((stat) => [
       Number(stat.hashrate1m),
       Number(stat.hashrate5m),
+      Number(stat.hashrate15m),
       Number(stat.hashrate1hr),
+      Number(stat.hashrate6hr),
       Number(stat.hashrate1d),
       Number(stat.hashrate7d),
     ])

--- a/components/PoolStatsChart.tsx
+++ b/components/PoolStatsChart.tsx
@@ -131,21 +131,21 @@ export default function PoolStatsChart({ data }: PoolStatsChartProps) {
   ];
 
   // Calculate the maximum hashrate
-  const hashrateFields: (keyof PoolStats)[] = [
-    'hashrate5m',
-    'hashrate15m',
-    'hashrate1hr',
-    'hashrate6hr',
-    'hashrate1d',
-    'hashrate7d',
-  ];
-  const maxHashrate = data
-    .flatMap((entry) => hashrateFields.map((field) => entry[field]))
-    .reduce((max, current) => (max > current ? max : current), BigInt(0));
+  const maxHashrate = Math.max(
+    ...data.flatMap((stat) => [
+      Number(stat.hashrate1m),
+      Number(stat.hashrate5m),
+      Number(stat.hashrate1hr),
+      Number(stat.hashrate1d),
+      Number(stat.hashrate7d),
+    ])
+  );
 
   // Find out the nearest ISO unit
   const hashrateUnit: ISOUnit = findISOUnit(Number(maxHashrate));
   const hashrateDivisor: number = hashrateUnit.threshold;
+  console.log(maxHashrate);
+  console.log(hashrateUnit);
 
   // Reverse the data array
   const reversedData = [...data].reverse();

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -13,7 +13,6 @@ const isoUnits: ISOUnit[] = [
   { threshold: 1e9, iso: 'G' },
   { threshold: 1e6, iso: 'M' },
   { threshold: 1e3, iso: 'k' },
-  { threshold: 1e0, iso: '' },
 ] as const;
 
 


### PR DESCRIPTION
Updated the maxHashrate calculation by casting datapoints to Nunber() first.  For some reason, the comparison operator was not working correctly in all cases for the Bigints().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calculation of maximum hashrate to include all relevant time intervals and ensure accurate numeric comparison.

* **Refactor**
  * Updated formatting logic by removing an unused ISO unit for cleaner number and hashrate display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->