### PR TITLE
Resolved divide by zero errors.

### DIFF
--- a/components/PoolStatsDisplay.tsx
+++ b/components/PoolStatsDisplay.tsx
@@ -129,7 +129,7 @@ export default function PoolStatsDisplay({
               <div className="stat">
                 <div className="stat-title">Avg Time to Find a Block</div>
                 <div className="stat-value text-2xl">
-                  {stats.hashrate6hr && stats.diff
+                  {Number(stats.hashrate6hr) > 0 && Number(stats.diff) > 0
                     ? formatDuration(
                         calculateAverageTimeToBlock(
                           stats.hashrate6hr,

--- a/components/PoolStatsDisplay.tsx
+++ b/components/PoolStatsDisplay.tsx
@@ -20,7 +20,6 @@ interface PoolStatsDisplayProps {
   stats: PoolStats;
   historicalStats: PoolStats[];
 }
-
 export default function PoolStatsDisplay({
   stats,
   historicalStats,
@@ -129,15 +128,21 @@ export default function PoolStatsDisplay({
               <div className="stat">
                 <div className="stat-title">Avg Time to Find a Block</div>
                 <div className="stat-value text-2xl">
-                  {Number(stats.hashrate6hr) > 0 && Number(stats.diff) > 0
-                    ? formatDuration(
-                        calculateAverageTimeToBlock(
-                          stats.hashrate6hr,
-                          (BigInt(stats.accepted) * BigInt(10000)) /
-                            BigInt(Math.round(Number(stats.diff) * 100))
+                  {(() => {
+                    const roundedDiffFactor = Math.round(
+                      Number(stats.diff) * 100
+                    );
+                    return Number(stats.hashrate6hr) > 0 &&
+                      roundedDiffFactor > 0
+                      ? formatDuration(
+                          calculateAverageTimeToBlock(
+                            stats.hashrate6hr,
+                            (BigInt(stats.accepted) * BigInt(10000)) /
+                              BigInt(roundedDiffFactor)
+                          )
                         )
-                      )
-                    : 'N/A'}
+                      : 'N/A';
+                  })()}
                 </div>
                 <div className="stat-desc">
                   <Link

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -120,11 +120,20 @@ export function getPercentageChangeColor(change: number | 'N/A'): string {
 }
 
 // Difficulty is assumed to be in T, hashrate in H/s
-export function calculateAverageTimeToBlock(hashRate: bigint, difficulty: number | bigint, units?: string): number {
+export function calculateAverageTimeToBlock(hashRate: bigint | number | string, difficulty: number | bigint, units?: string): number {
   const hashesPerDifficulty = BigInt(2 ** 32);
+  const hashRateBigInt =
+    typeof hashRate === 'bigint'
+      ? hashRate
+      : BigInt(Math.round(Number(hashRate)));
+
+  if (hashRateBigInt === BigInt(0)) {
+    return 0;
+  }
+
   let convertedDifficulty: bigint;
   if (typeof difficulty === 'number') {
-  if (units === 'T') {
+    if (units === 'T') {
       convertedDifficulty = BigInt(Math.round(difficulty * 1e12)); // Convert T
     } else {
       convertedDifficulty = BigInt(Math.round(difficulty)); // No units
@@ -132,12 +141,28 @@ export function calculateAverageTimeToBlock(hashRate: bigint, difficulty: number
   } else {
     convertedDifficulty = difficulty;
   }
-  return Number((BigInt(convertedDifficulty) * BigInt(hashesPerDifficulty)) / BigInt(hashRate));
+
+  if (convertedDifficulty === BigInt(0)) {
+    return 0;
+  }
+
+  return Number((convertedDifficulty * BigInt(hashesPerDifficulty)) / hashRateBigInt);
 }
 
 // Difficulty is assumed to be a % of network, hashrate in H/s
 export function calculateBlockChances(hashRate: bigint, difficulty: number, accepted: bigint): { [key: string]: string } {
-  const networkDiff = (BigInt(accepted) / BigInt(Math.round(Number(difficulty) * 100))) * BigInt(10000);
+  const difficultyFactor = Math.round(Number(difficulty) * 100);
+  if (difficultyFactor === 0 || accepted === BigInt(0)) {
+    return {
+      '1h': '<0.001%',
+      '1d': '<0.001%',
+      '1w': '<0.001%',
+      '1m': '<0.001%',
+      '1y': '<0.001%',
+    };
+  }
+
+  const networkDiff = (BigInt(accepted) / BigInt(difficultyFactor)) * BigInt(10000);
   const hashesPerDifficulty = BigInt(2 ** 32);
   // const convertedDifficulty = BigInt(Math.round(Number(networkDiff) * 1e12));
   const probabilityPerHash = 1 / Number(networkDiff * hashesPerDifficulty);

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -213,7 +213,9 @@ export function calculateAverageTimeToBlock(hashRate: bigint | number | string, 
  */
 export function calculateBlockChances(hashRate: bigint, difficulty: number, accepted: bigint): { [key: string]: string} {
   const difficultyFactor = Math.round(Number(difficulty) * 100);
-  if (difficultyFactor === 0 || accepted === BigInt(0)) {
+  const acceptedBigInt = typeof accepted === 'bigint' ? accepted : BigInt(accepted);
+  
+  if (difficultyFactor === 0 || acceptedBigInt === BigInt(0)) {
     return {
       '1h': '<0.001%',
       '1d': '<0.001%',
@@ -223,7 +225,7 @@ export function calculateBlockChances(hashRate: bigint, difficulty: number, acce
     };
   }
 
-  const networkDiff = (accepted * BigInt(10000)) / BigInt(difficultyFactor);
+  const networkDiff = (acceptedBigInt * BigInt(10000)) / BigInt(difficultyFactor);
   const hashesPerDifficulty = BigInt(2 ** 32);
   if (networkDiff === BigInt(0)) {
     return {

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -215,7 +215,7 @@ export function calculateBlockChances(hashRate: bigint, difficulty: number, acce
   const difficultyFactor = Math.round(Number(difficulty) * 100);
   const acceptedBigInt = typeof accepted === 'bigint' ? accepted : BigInt(accepted);
   
-  if (!Number.isFinite(difficultyFactor) || difficultyFactor <= 0 || acceptedBigInt <= 0n) {
+  if (!Number.isFinite(difficultyFactor) || difficultyFactor <= 0 || acceptedBigInt <= BigInt(0)) {
     return {
       '1h': '<0.001%',
       '1d': '<0.001%',

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,3 +1,9 @@
+/**
+ * Represents an International System of Units (SI) prefix.
+ * @interface ISOUnit
+ * @property {number} threshold - The numeric value at which this unit is used (e.g., 1e12 for Tera)
+ * @property {string} iso - The ISO/SI prefix symbol (e.g., 'T' for Tera, 'G' for Giga)
+ */
 export interface ISOUnit {
   threshold: number;
   iso: string;
@@ -16,6 +22,11 @@ const isoUnits: ISOUnit[] = [
 ] as const;
 
 
+/**
+ * Formats a number with appropriate ISO unit prefix (Z, E, P, T, G, M, k).
+ * @param {number | bigint | string} num - The number to format
+ * @returns {string} The formatted number with unit prefix (e.g., "1.23 T") or locale string for small numbers
+ */
 export function formatNumber(num: number | bigint | string): string {
   const absNum = Math.abs(Number(num));
 
@@ -28,6 +39,11 @@ export function formatNumber(num: number | bigint | string): string {
   return num.toLocaleString();
 }
 
+/**
+ * Formats a hashrate value with appropriate ISO unit prefix and H/s suffix.
+ * @param {string | bigint | number} num - The hashrate in H/s to format
+ * @returns {string} The formatted hashrate with unit suffix (e.g., "1.23 TH/s")
+ */
 export function formatHashrate(num: string | bigint | number): string {
   const numberValue = Number(num);
   const absNum = Math.abs(numberValue);
@@ -41,6 +57,12 @@ export function formatHashrate(num: string | bigint | number): string {
   return numberValue.toLocaleString(undefined, { maximumFractionDigits: 2 }) + ' H/s';
 }
 
+/**
+ * Converts a hashrate string with ISO unit prefix to a bigint value in H/s.
+ * Supports scientific notation (e.g., "1.5e2T" for 150 Tera).
+ * @param {string} value - The hashrate string (e.g., "1.23T" or "1.5e2G")
+ * @returns {bigint} The hashrate in H/s as a bigint
+ */
 export function convertHashrate(value: string): bigint {
   // Updated regex to handle scientific notation
   const match = value.match(/^(\d+(\.\d+)?(?:e[+-]\d+)?)([ZEPTGMK])$/i);
@@ -54,6 +76,11 @@ export function convertHashrate(value: string): bigint {
   return BigInt(value);
 };
 
+/**
+ * Finds the most appropriate ISO unit for a given number.
+ * @param {number} num - The number to find the unit for
+ * @returns {ISOUnit} The ISO unit with the highest threshold that the number meets
+ */
 export function findISOUnit(num: number): ISOUnit {
   const absNum = Math.abs(num);
 
@@ -66,6 +93,12 @@ export function findISOUnit(num: number): ISOUnit {
   return {threshold: 1, iso: ''};
 }
 
+/**
+ * Formats a date/timestamp as a human-readable "time ago" string.
+ * @param {Date | number | string} date - The date to format
+ * @param {number} [minDiff=1] - The minimum difference in minutes before returning a relative time (defaults to 1)
+ * @returns {string} The formatted time (e.g., "5 mins ago", "2 hours 30 mins ago", or "Recently")
+ */
 export function formatTimeAgo(date: Date | number | string, minDiff: number = 1): string {
   const now = new Date();
   const lastUpdate = new Date(date);
@@ -88,6 +121,12 @@ export function formatTimeAgo(date: Date | number | string, minDiff: number = 1)
   }
 }
 
+/**
+ * Formats a duration in seconds as a human-readable string.
+ * Shows years, days, hours, and minutes as applicable.
+ * @param {number} seconds - The duration in seconds
+ * @returns {string} The formatted duration (e.g., "2d 3h 45m", "~∞" for very large values)
+ */
 export function formatDuration(seconds: number): string {
   if (seconds > 8000000000000) {
     return '~∞';
@@ -107,6 +146,12 @@ export function formatDuration(seconds: number): string {
   return parts.length > 0 ? parts.join(' ') : '0m';
 }
 
+/**
+ * Calculates the percentage change between two values.
+ * @param {number} currentValue - The current value
+ * @param {number} pastValue - The past/previous value for comparison
+ * @returns {number | 'N/A'} The percentage change, or 'N/A' if pastValue is zero (to avoid division by zero)
+ */
 export function calculatePercentageChange(currentValue: number, pastValue: number): number | 'N/A' {
   if (pastValue === 0) return 'N/A';
 
@@ -114,12 +159,24 @@ export function calculatePercentageChange(currentValue: number, pastValue: numbe
   return Number(percentageChange.toFixed(2));
 }
 
+/**
+ * Returns a Tailwind CSS color class for displaying a percentage change.
+ * @param {number | 'N/A'} change - The percentage change value
+ * @returns {string} Tailwind color class: 'text-success' for positive, 'text-error' for negative, or 'text-base-content' for N/A or zero
+ */
 export function getPercentageChangeColor(change: number | 'N/A'): string {
   if (change === 'N/A') return 'text-base-content';
   return change > 0 ? 'text-success' : change < 0 ? 'text-error' : 'text-base-content';
 }
 
-// Difficulty is assumed to be in the specified units (e.g., 'T' for terahash), hashrate in H/s
+/**
+ * Calculates the average time to find a block given hashrate and difficulty.
+ * Returns 0 if hashrate or difficulty is zero to avoid division by zero.
+ * @param {bigint | number | string} hashRate - The hashrate in H/s
+ * @param {number | bigint} difficulty - The difficulty value
+ * @param {string} [units] - Optional ISO unit prefix for the difficulty (e.g., 'T' for terahash). If not provided, difficulty is assumed to be already in base units.
+ * @returns {number} The average time to block in seconds
+ */
 export function calculateAverageTimeToBlock(hashRate: bigint | number | string, difficulty: number | bigint, units?: string): number {
   const hashesPerDifficulty = BigInt(2 ** 32);
   const hashRateBigInt =
@@ -146,8 +203,15 @@ export function calculateAverageTimeToBlock(hashRate: bigint | number | string, 
   return Number((convertedDifficulty * BigInt(hashesPerDifficulty)) / hashRateBigInt);
 }
 
-// Difficulty is assumed to be a % of network, hashrate in H/s
-export function calculateBlockChances(hashRate: bigint, difficulty: number, accepted: bigint): { [key: string]: string } {
+/**
+ * Calculates the probability of finding a block within various time periods.
+ * Returns early with minimal probabilities if inputs are zero.
+ * @param {bigint} hashRate - The hashrate in H/s
+ * @param {number} difficulty - The difficulty as a percentage of network difficulty
+ * @param {bigint} accepted - The number of accepted shares
+ * @returns {object} An object with keys '1h', '1d', '1w', '1m', '1y' mapping to probability strings (e.g., "0.123%", "<0.001%")
+ */
+export function calculateBlockChances(hashRate: bigint, difficulty: number, accepted: bigint): { [key: string]: string} {
   const difficultyFactor = Math.round(Number(difficulty) * 100);
   if (difficultyFactor === 0 || accepted === BigInt(0)) {
     return {
@@ -193,6 +257,12 @@ export function calculateBlockChances(hashRate: bigint, difficulty: number, acce
   }, {} as { [key: string]: string });
 }
 
+/**
+ * Serializes data to JSON, converting all bigint values to strings.
+ * Useful for preparing TypeORM entity data for JSON serialization (e.g., for API responses).
+ * @param {any} data - The data object containing bigint values
+ * @returns {any} The serialized data with bigints converted to strings
+ */
 export function serializeData(data: any) {
   return JSON.parse(
     JSON.stringify(data, (key, value) =>

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -159,9 +159,17 @@ export function calculateBlockChances(hashRate: bigint, difficulty: number, acce
     };
   }
 
-  const networkDiff = (BigInt(accepted) / BigInt(difficultyFactor)) * BigInt(10000);
+  const networkDiff = (BigInt(accepted) * BigInt(10000)) / BigInt(difficultyFactor);
   const hashesPerDifficulty = BigInt(2 ** 32);
-  // const convertedDifficulty = BigInt(Math.round(Number(networkDiff) * 1e12));
+  if (networkDiff === BigInt(0) || hashesPerDifficulty === BigInt(0)) {
+    return {
+      '1h': '<0.001%',
+      '1d': '<0.001%',
+      '1w': '<0.001%',
+      '1m': '<0.001%',
+      '1y': '<0.001%',
+    };
+  }
   const probabilityPerHash = 1 / Number(networkDiff * hashesPerDifficulty);
   const hashesPerSecond = Number(hashRate);
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -119,7 +119,7 @@ export function getPercentageChangeColor(change: number | 'N/A'): string {
   return change > 0 ? 'text-success' : change < 0 ? 'text-error' : 'text-base-content';
 }
 
-// Difficulty is assumed to be in T, hashrate in H/s
+// Difficulty is assumed to be in the specified units (e.g., 'T' for terahash), hashrate in H/s
 export function calculateAverageTimeToBlock(hashRate: bigint | number | string, difficulty: number | bigint, units?: string): number {
   const hashesPerDifficulty = BigInt(2 ** 32);
   const hashRateBigInt =
@@ -133,11 +133,8 @@ export function calculateAverageTimeToBlock(hashRate: bigint | number | string, 
 
   let convertedDifficulty: bigint;
   if (typeof difficulty === 'number') {
-    if (units === 'T') {
-      convertedDifficulty = BigInt(Math.round(difficulty * 1e12)); // Convert T
-    } else {
-      convertedDifficulty = BigInt(Math.round(difficulty)); // No units
-    }
+    const isoUnit = isoUnits.find((u) => u.iso.toUpperCase() === units?.toUpperCase()) || { threshold: 1, iso: '' };
+    convertedDifficulty = BigInt(Math.round(difficulty * isoUnit.threshold));
   } else {
     convertedDifficulty = difficulty;
   }
@@ -195,3 +192,4 @@ export function serializeData(data: any) {
     )
   );
 }
+

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -215,7 +215,7 @@ export function calculateBlockChances(hashRate: bigint, difficulty: number, acce
   const difficultyFactor = Math.round(Number(difficulty) * 100);
   const acceptedBigInt = typeof accepted === 'bigint' ? accepted : BigInt(accepted);
   
-  if (difficultyFactor === 0 || acceptedBigInt === BigInt(0)) {
+  if (!Number.isFinite(difficultyFactor) || difficultyFactor <= 0 || acceptedBigInt <= 0n) {
     return {
       '1h': '<0.001%',
       '1d': '<0.001%',

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -159,9 +159,9 @@ export function calculateBlockChances(hashRate: bigint, difficulty: number, acce
     };
   }
 
-  const networkDiff = (BigInt(accepted) * BigInt(10000)) / BigInt(difficultyFactor);
+  const networkDiff = (accepted * BigInt(10000)) / BigInt(difficultyFactor);
   const hashesPerDifficulty = BigInt(2 ** 32);
-  if (networkDiff === BigInt(0) || hashesPerDifficulty === BigInt(0)) {
+  if (networkDiff === BigInt(0)) {
     return {
       '1h': '<0.001%',
       '1d': '<0.001%',


### PR DESCRIPTION
This patch resolves a divide-by-zero error when the pool.status file reports a hashrate of 0, and these two commands are run:

pnpm migration:run
pnpm build

This resolves issue #39 and #23.  Also, the hard coded reference to the ISO unit of "T" has been removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Avg Time to Find a Block" now reliably shows "N/A" when hashrate or difficulty are non-positive/invalid.
  * Stronger zero-guards prevent misleading durations and ensure block chance displays as "<0.001%" for extremely small probabilities or missing network difficulty.
  * Difficulty unit handling made more consistent for accurate calculations.

* **Documentation**
  * Added inline documentation for multiple utility routines to improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->