### PR TITLE
Update the build target to ES2020.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,8 @@
 
 ## Code Style
 
-- TypeScript with `strictNullChecks: true` but `strict: false` for BigInt compatibility
+- TypeScript with `strictNullChecks: true` and `strict: false` for gradual type checking
+- JavaScript standard: ES2020
 - Formatting: Prettier (see .prettierrc), ESLint (see .eslintrc.json)
 - Reference: [utils/helpers.ts](utils/helpers.ts) for formatting patterns, [lib/api.ts](lib/api.ts) for query structure
 
@@ -10,7 +11,7 @@
 
 - Next.js 14 App Router with server-first rendering and 60-second ISR revalidation
 - TypeORM entities: PoolStats, User, UserStats, Worker, WorkerStats
-- Cache layers: Node-cache (60-90s) + HTTP ISR (60s) for performance
+- Cache layers: Node-cache + HTTP ISR (60s) for performance
 - Batch processing for data synchronization (see [scripts/updateUsers.ts](scripts/updateUsers.ts))
 
 ## Build and Test
@@ -30,3 +31,4 @@
 - Cache-aside pattern in [lib/api.ts](lib/api.ts)
 
 See [README.md](README.md) for deployment and environment setup.
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,8 @@
 
 ## Code Style
 
-- TypeScript with `strictNullChecks: true` but `strict: false` for BigInt compatibility
+- TypeScript with `strictNullChecks: true` and `strict: false` for gradual type checking
+- JavaScript standard: ES2020
 - Formatting: Prettier (see .prettierrc), ESLint (see .eslintrc.json)
 - Reference: [utils/helpers.ts](utils/helpers.ts) for formatting patterns, [lib/api.ts](lib/api.ts) for query structure
 
@@ -10,7 +11,7 @@
 
 - Next.js 14 App Router with server-first rendering and 60-second ISR revalidation
 - TypeORM entities: PoolStats, User, UserStats, Worker, WorkerStats
-- Cache layers: Node-cache (60-90s) + HTTP ISR (60s) for performance
+- Cache layers: Node-cache + HTTP ISR (60s) for performance
 - Batch processing for data synchronization (see [scripts/updateUsers.ts](scripts/updateUsers.ts))
 
 ## Build and Test

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# Project Guidelines
+
+## Code Style
+
+- TypeScript with `strictNullChecks: true` but `strict: false` for BigInt compatibility
+- Formatting: Prettier (see .prettierrc), ESLint (see .eslintrc.json)
+- Reference: [utils/helpers.ts](utils/helpers.ts) for formatting patterns, [lib/api.ts](lib/api.ts) for query structure
+
+## Architecture
+
+- Next.js 14 App Router with server-first rendering and 60-second ISR revalidation
+- TypeORM entities: PoolStats, User, UserStats, Worker, WorkerStats
+- Cache layers: Node-cache (60-90s) + HTTP ISR (60s) for performance
+- Batch processing for data synchronization (see [scripts/updateUsers.ts](scripts/updateUsers.ts))
+
+## Build and Test
+
+- Install: `pnpm install`
+- Dev: `pnpm dev`
+- Build: `pnpm build`
+- Test: `pnpm test`
+- Migrations: `pnpm migration:run`
+- Data seeding: `pnpm seed`
+
+## Conventions
+
+- Always use `serializeData()` for ORM entities before JSON responses (BigInt safety)
+- Formatting helpers in [utils/helpers.ts](utils/helpers.ts): `formatHashrate()`, `formatTimeAgo()`, etc.
+- Bitcoin address validation: `validateBitcoinAddress()` in API routes
+- Cache-aside pattern in [lib/api.ts](lib/api.ts)
+
+See [README.md](README.md) for deployment and environment setup.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "migration:run": "ts-node -P tsconfig.scripts.json ./scripts/migration.ts",
     "migration:run:skip": "ts-node -P tsconfig.scripts.json ./scripts/migration.ts --skip-initial"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "dependencies": {
     "@bitcoinerlab/secp256k1": "^1.2.0",
     "@tanstack/react-query": "^5.90.21",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "ES2020",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
This small pull request updates the build target to more modern, ES2020, which still supports older versions of Node.js (such as v18.19.1, which ships in Ubuntu 24.04.4 LTS), and has broad browser support.

copilot-instructions.md has been added to describe the project and improve GitHub Copilot's ability to make changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compilation target to ES2020
  * Added minimum Node.js engine requirement (>=18.0.0)

* **Documentation**
  * Added project-wide development and architectural guidelines covering coding style, build/test/migration workflows, API/response conventions, caching and sync patterns, and recommended utilities for safe serialization and validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->