### PR TITLE
Resolve error in calculation for the odds of finding a block

### DIFF
--- a/__tests__/utils/helpers.test.ts
+++ b/__tests__/utils/helpers.test.ts
@@ -97,12 +97,30 @@ describe('Helper Functions', () => {
 
   describe('calculateBlockChances', () => {
     it('calculates block chances correctly', () => {
-      const chances = calculateBlockChances(BigInt(1000000000000), 1, BigInt(100000000000000));
+      const chances = calculateBlockChances(
+        BigInt(1000000000000),
+        1e14,
+        BigInt(100000000000000)
+      );
       expect(chances['1h']).toBe('<0.001%');
       expect(chances['1d']).toMatch(/\d+\.\d+%|<0\.001%/);
       expect(chances['1w']).toMatch(/\d+\.\d+%|<0\.001%/);
       expect(chances['1m']).toMatch(/\d+\.\d+%|<0\.001%/);
       expect(chances['1y']).toMatch(/\d+\.\d+%|<0\.001%/);
+    });
+
+    it('returns 0.038% for 7.18 TH/s and current difficulty', () => {
+      const chances = calculateBlockChances(
+        '7180000000000',
+        138955357012247.3,
+        BigInt(1)
+      );
+      expect(chances['1y']).toBe('0.038%');
+    });
+
+    it('returns fallback for invalid non-numeric accepted/hashRate values', () => {
+      expect(calculateBlockChances('not-a-number', 1e14, BigInt(100000000000000))['1h']).toBe('<0.001%');
+      expect(calculateBlockChances(BigInt(1000000000000), 1e14, 'not-a-number')['1h']).toBe('<0.001%');
     });
   });
 });

--- a/app/users/[address]/page.tsx
+++ b/app/users/[address]/page.tsx
@@ -10,6 +10,7 @@ import {
   getUserWithWorkersAndStats,
   getUserHistoricalStats,
   getLatestPoolStats,
+  getNetworkDifficulty,
 } from '../../../lib/api';
 import {
   formatHashrate,
@@ -26,11 +27,13 @@ export default async function UserPage({
 }: {
   params: { address: string };
 }) {
-  const [userORM, statsORM, historicalStatsORM] = await Promise.all([
-    getUserWithWorkersAndStats(params.address),
-    getLatestPoolStats(),
-    getUserHistoricalStats(params.address),
-  ]);
+  const [userORM, statsORM, historicalStatsORM, networkDifficulty] =
+    await Promise.all([
+      getUserWithWorkersAndStats(params.address),
+      getLatestPoolStats(),
+      getUserHistoricalStats(params.address),
+      getNetworkDifficulty(),
+    ]);
 
   if (!userORM) {
     notFound();
@@ -182,10 +185,10 @@ export default async function UserPage({
         <div className="stat">
           <div className="stat-title">1 Day</div>
           <div className="stat-value text-3xl">
-            {latestStats.hashrate1hr && stats?.diff
+            {Number(latestStats.hashrate1hr) > 0 && networkDifficulty
               ? calculateBlockChances(
                   latestStats.hashrate1hr,
-                  Number(stats.diff),
+                  networkDifficulty,
                   stats.accepted
                 )['1d']
               : 'N/A'}
@@ -194,10 +197,10 @@ export default async function UserPage({
         <div className="stat">
           <div className="stat-title">1 Week</div>
           <div className="stat-value text-3xl">
-            {latestStats.hashrate1hr && stats?.diff
+            {Number(latestStats.hashrate1hr) > 0 && networkDifficulty
               ? calculateBlockChances(
                   latestStats.hashrate1hr,
-                  Number(stats.diff),
+                  networkDifficulty,
                   stats.accepted
                 )['1w']
               : 'N/A'}
@@ -206,10 +209,10 @@ export default async function UserPage({
         <div className="stat">
           <div className="stat-title">1 Month</div>
           <div className="stat-value text-3xl">
-            {latestStats.hashrate1hr && stats?.diff
+            {Number(latestStats.hashrate1hr) > 0 && networkDifficulty
               ? calculateBlockChances(
                   latestStats.hashrate1hr,
-                  Number(stats.diff),
+                  networkDifficulty,
                   stats.accepted
                 )['1m']
               : 'N/A'}
@@ -218,10 +221,10 @@ export default async function UserPage({
         <div className="stat">
           <div className="stat-title">1 Year</div>
           <div className="stat-value text-3xl">
-            {latestStats.hashrate1hr && stats?.diff
+            {Number(latestStats.hashrate1hr) > 0 && networkDifficulty
               ? calculateBlockChances(
                   latestStats.hashrate1hr,
-                  Number(stats.diff),
+                  networkDifficulty,
                   stats.accepted
                 )['1y']
               : 'N/A'}

--- a/components/PoolStatsDisplay.tsx
+++ b/components/PoolStatsDisplay.tsx
@@ -50,7 +50,7 @@ export default function PoolStatsDisplay({
     if (key.startsWith('hashrate') || key.startsWith('SPS')) {
       return key.replace(/^(hashrate|SPS)/, '').toUpperCase();
     } else if (key === 'diff') {
-      return '% of Network Diff';
+      return 'Pool Difficulty (% of network)';
     } else if (key === 'bestshare') {
       return 'Best Diff';
     }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -56,6 +56,44 @@ export async function getLatestPoolStats(): Promise<PoolStats | null> {
   return result;
 }
 
+export async function getNetworkDifficulty(): Promise<number | null> {
+  const cacheKey = 'network:difficulty';
+  const cached = cache.get<number | null>(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  try {
+    const response = await fetch('https://mempool.space/api/blocks', {
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch network difficulty: ${response.status}`);
+    }
+
+    const blocks = (await response.json()) as Array<{
+      difficulty?: number;
+    }>;
+
+    const difficulty = blocks?.[0]?.difficulty;
+    if (
+      typeof difficulty !== 'number' ||
+      !Number.isFinite(difficulty) ||
+      difficulty <= 0
+    ) {
+      throw new Error('Invalid difficulty from network API');
+    }
+
+    cache.set(cacheKey, difficulty, 3600);
+    return difficulty;
+  } catch (error) {
+    console.error('Error fetching network difficulty:', error);
+    cache.set(cacheKey, null, 60);
+    return null;
+  }
+}
+
 /**
  * Fetch a recent history of pool stats records, limited to a fixed window.
  *

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -207,15 +207,32 @@ export function calculateAverageTimeToBlock(hashRate: bigint | number | string, 
  * Calculates the probability of finding a block within various time periods.
  * Returns early with minimal probabilities if inputs are zero.
  * @param {bigint} hashRate - The hashrate in H/s
- * @param {number} difficulty - The difficulty as a percentage of network difficulty
+ * @param {number} difficulty - The Bitcoin network difficulty value
  * @param {bigint} accepted - The number of accepted shares
  * @returns {object} An object with keys '1h', '1d', '1w', '1m', '1y' mapping to probability strings (e.g., "0.123%", "<0.001%")
  */
-export function calculateBlockChances(hashRate: bigint, difficulty: number, accepted: bigint): { [key: string]: string} {
-  const difficultyFactor = Math.round(Number(difficulty) * 100);
-  const acceptedBigInt = typeof accepted === 'bigint' ? accepted : BigInt(accepted);
-  
-  if (!Number.isFinite(difficultyFactor) || difficultyFactor <= 0 || acceptedBigInt <= BigInt(0)) {
+export function calculateBlockChances(
+  hashRate: bigint | number | string,
+  difficulty: number | bigint,
+  accepted: bigint | number | string
+): { [key: string]: string} {
+  // `difficulty` is the absolute Bitcoin network difficulty.
+  const acceptedBigInt =
+    typeof accepted === 'bigint'
+      ? accepted
+      : Number.isFinite(Number(accepted))
+      ? BigInt(Math.round(Number(accepted)))
+      : null;
+
+  const difficultyAbsolute =
+    typeof difficulty === 'number' ? difficulty : Number(difficulty);
+
+  if (
+    !Number.isFinite(difficultyAbsolute) ||
+    difficultyAbsolute <= 0 ||
+    acceptedBigInt === null ||
+    acceptedBigInt <= BigInt(0)
+  ) {
     return {
       '1h': '<0.001%',
       '1d': '<0.001%',
@@ -225,9 +242,8 @@ export function calculateBlockChances(hashRate: bigint, difficulty: number, acce
     };
   }
 
-  const networkDiff = (acceptedBigInt * BigInt(10000)) / BigInt(difficultyFactor);
   const hashesPerDifficulty = BigInt(2 ** 32);
-  if (networkDiff === BigInt(0)) {
+  if (difficultyAbsolute === 0) {
     return {
       '1h': '<0.001%',
       '1d': '<0.001%',
@@ -236,8 +252,26 @@ export function calculateBlockChances(hashRate: bigint, difficulty: number, acce
       '1y': '<0.001%',
     };
   }
-  const probabilityPerHash = 1 / Number(networkDiff * hashesPerDifficulty);
-  const hashesPerSecond = Number(hashRate);
+
+  const probabilityPerHash = 1 / (difficultyAbsolute * Number(hashesPerDifficulty));
+  const hashRateBigInt =
+    typeof hashRate === 'bigint'
+      ? hashRate
+      : Number.isFinite(Number(hashRate))
+      ? BigInt(Math.round(Number(hashRate)))
+      : null;
+
+  if (hashRateBigInt === null || hashRateBigInt <= BigInt(0)) {
+    return {
+      '1h': '<0.001%',
+      '1d': '<0.001%',
+      '1w': '<0.001%',
+      '1m': '<0.001%',
+      '1y': '<0.001%',
+    };
+  }
+
+  const hashesPerSecond = Number(hashRateBigInt);
 
   const periodsInSeconds = {
     '1h': 3600,


### PR DESCRIPTION
The calculation was incorrectly using the "diff" field from the ckpool "pool.status" API file, which is the pool difficulty relative to the Bitcoin network difficulty.

Various improvements have been made to enhance the precision of the calculations, as well as an hourly API call to mempool.space to retrieve the current Bitcoin network difficulty.

One issue is that ckstats will always assume it is on mainnet for this calculation, even when it is running on testnet4.  This issue is acceptable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Odds calculations now use live network difficulty for more accurate block-finding estimates.

* **UI Updates**
  * Pool difficulty label clarified to “Pool Difficulty (% of network)”.

* **Bug Fixes / Reliability**
  * Block-odds calculations handle varied/invalid inputs more robustly and show a "<0.001%" fallback when data is missing or invalid.

* **Tests**
  * Added tests covering edge cases and specific expected odds outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->